### PR TITLE
Chore: sentry yml 수정

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -47,9 +47,10 @@ jobs:
           SENTRY_ORG: junyup
           SENTRY_PROJECT: coreal_project
         run: |
+          export SENTRY_LOG_LEVEL=debug
           export VERSION=$(sentry-cli releases propose-version)
           sentry-cli releases new $VERSION
-          sentry-cli releases set-commits --auto $VERSION
+          sentry-cli releases set-commits --auto --ignore-missing $VERSION
 
       - name: Finalize Sentry release
         env:
@@ -57,5 +58,6 @@ jobs:
           SENTRY_ORG: junyup
           SENTRY_PROJECT: coreal_project
         run: |
+          export SENTRY_LOG_LEVEL=debug
           export VERSION=$(sentry-cli releases propose-version)
           sentry-cli releases finalize $VERSION

--- a/front/.env.development
+++ b/front/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_TEST_API = http://localhost:5000


### PR DESCRIPTION
이전 SHA를 찾을 수 없는 경우 무시하고 릴리즈하도록 변경