### PR TITLE
Feature : 모임 상세 페이지 레이아웃 구현

### DIFF
--- a/front/src/app/gatherings/[id]/_components/CommentDisplay.tsx
+++ b/front/src/app/gatherings/[id]/_components/CommentDisplay.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import CommentForm from "./CommentForm";
+import { useCommentStore } from "@/store/gatheringsDetail/useCommentStore";
+import { Comment } from "@/types/gatheringsDetail/comment";
+
+//코드의 가독성을 위해 코드를 분리하지않고 밀접한 관계를 가진 컴포넌트를 같은 파일내에 작성을 했습니다
+
+export default function CommentDisplay() {
+  const { comments, addComment, addReply, deleteComment } = useCommentStore();
+  const [replyingTo, setReplyingTo] = useState<number | null>(null);
+
+  const renderComment = (comment: Comment, isReply = false) => (
+    <div key={comment.id} className={`mb-4 ${isReply ? "ml-12" : ""}`}>
+      <div className="flex items-start space-x-4">
+        <div className="w-10 h-10 bg-gray-400 rounded-full flex-shrink-0" />
+        <div className="flex-grow">
+          <p className="text-xl text-[#484848] font-semibold">{comment.user}</p>
+          <p className="text-lg text-[#484848] mt-1">{comment.text}</p>
+          <div className="flex space-x-2 text-sm text-[#6a6a6a] mt-1">
+            <span>{comment.createdAt}</span>
+            <button onClick={() => setReplyingTo(comment.id)}>답글달기</button>
+            <button onClick={() => deleteComment(comment.id)}>삭제</button>
+          </div>
+        </div>
+      </div>
+      {replyingTo === comment.id && (
+        <div className="mt-2 ml-14">
+          <CommentForm
+            onSubmit={(text) => {
+              addReply(comment.id, text);
+              setReplyingTo(null);
+            }}
+            placeholder="답글을 작성해주세요"
+          />
+        </div>
+      )}
+    </div>
+  );
+
+  const renderCommentWithReplies = (comment: Comment) => {
+    const flattenReplies = (c: Comment): Comment[] => {
+      return [c, ...(c.replies?.flatMap(flattenReplies) || [])];
+    };
+
+    const allComments = flattenReplies(comment);
+
+    return (
+      <div key={comment.id} className="mb-8">
+        {allComments.map((c, index) => renderComment(c, index > 0))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full max-w-[1200px] mx-auto mt-8">
+      <p className="text-[28px] font-semibold text-[#484848] mb-6">댓글</p>
+      {comments.map(renderCommentWithReplies)}
+      <CommentForm onSubmit={addComment} />
+    </div>
+  );
+}

--- a/front/src/app/gatherings/[id]/_components/CommentDisplay.tsx
+++ b/front/src/app/gatherings/[id]/_components/CommentDisplay.tsx
@@ -12,7 +12,7 @@ export default function CommentDisplay() {
   const renderComment = (comment: Comment, isReply = false) => (
     <div key={comment.id} className={`mb-4 ${isReply ? "ml-12" : ""}`}>
       <div className="flex items-start space-x-4">
-        <div className="w-10 h-10 bg-gray-400 rounded-full flex-shrink-0" />
+        <div className="w-10 h-10  bg-gray-200 rounded-full" />
         <div className="flex-grow">
           <p className="text-xl text-[#484848] font-semibold">{comment.user}</p>
           <p className="text-lg text-[#484848] mt-1">{comment.text}</p>

--- a/front/src/app/gatherings/[id]/_components/CommentForm.tsx
+++ b/front/src/app/gatherings/[id]/_components/CommentForm.tsx
@@ -55,6 +55,7 @@ export default function CommentForm({
     >
       <textarea
         {...register("comment")}
+        //TODO : onKeyDown 쓰면 이상하게 오류가나감.. 수정필요
         onKeyPress={handleKeyPress}
         className="w-full text-lg leading-relaxed text-slate-700 bg-transparent border-none resize-none outline-none placeholder-slate-400"
         placeholder={placeholder}

--- a/front/src/app/gatherings/[id]/_components/CommentForm.tsx
+++ b/front/src/app/gatherings/[id]/_components/CommentForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const commentSchema = z.object({
+  comment: z
+    .string()
+    .min(1, "댓글을 입력해주세요.")
+    .max(300, "댓글은 300자를 초과할 수 없습니다."),
+});
+
+type CommentFormData = z.infer<typeof commentSchema>;
+
+interface CommentFormProps {
+  onSubmit: (text: string) => void;
+  placeholder?: string;
+}
+
+export default function CommentForm({
+  onSubmit,
+  placeholder = "댓글을 입력하세요.",
+}: CommentFormProps) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { isValid, isDirty },
+  } = useForm<CommentFormData>({
+    resolver: zodResolver(commentSchema),
+    mode: "onChange",
+  });
+
+  const commentLength = watch("comment")?.length || 0;
+
+  const handleFormSubmit = (data: CommentFormData) => {
+    onSubmit(data.comment);
+    reset();
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(handleFormSubmit)();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(handleFormSubmit)}
+      className="flex flex-col p-4 mt-10 w-full rounded-lg border border-zinc-300 bg-slate-100"
+    >
+      <textarea
+        {...register("comment")}
+        onKeyPress={handleKeyPress}
+        className="w-full text-lg leading-relaxed text-slate-700 bg-transparent border-none resize-none outline-none placeholder-slate-400"
+        placeholder={placeholder}
+      />
+      <div className="flex justify-between items-center mt-2">
+        <span className="text-sm text-slate-500">{commentLength}/300</span>
+        <button
+          type="submit"
+          className="px-4 py-2 text-sm font-bold text-white bg-violet-500 rounded border border-violet-500 hover:bg-violet-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={!isValid || !isDirty}
+        >
+          등록
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/front/src/app/gatherings/[id]/_components/DetailHeader.tsx
+++ b/front/src/app/gatherings/[id]/_components/DetailHeader.tsx
@@ -16,16 +16,12 @@ export default function DetailHeader() {
             [전라북도] 어플리케이션 개발
           </h1>
           <div className="flex items-center text-[20px] text-[#9a9a9a] gap-3">
-            {/* TODO : 글쓴이로 변경 */}
             <span>dkdkdkdkdkd</span>
             <Divider />
-            {/* TODO : 글쓴시간 으로 변경 */}
             <span>2024.09.08 20:28</span>
             <Divider />
-            {/* TODO : 버튼 동작시 어떻게 작동할지 논의  모달창? */}
             <button>{buttons.edit}</button>
             <Divider />
-            {/* TODO : 버튼 동작시 삭제 요청 */}
             <button>{buttons.delete}</button>
           </div>
         </div>

--- a/front/src/app/gatherings/[id]/_components/DetailHeader.tsx
+++ b/front/src/app/gatherings/[id]/_components/DetailHeader.tsx
@@ -1,5 +1,4 @@
-import { CiHeart } from "react-icons/ci";
-import { CiShare2 } from "react-icons/ci";
+import { CiHeart, CiShare2 } from "react-icons/ci";
 
 export default function DetailHeader() {
   const buttons = {

--- a/front/src/app/gatherings/[id]/_components/DetailProjectCard.tsx
+++ b/front/src/app/gatherings/[id]/_components/DetailProjectCard.tsx
@@ -11,7 +11,7 @@ function DetailProjectCard({
 }: DetailProjectCard) {
   return (
     <aside className="flex flex-col text-2xl font-bold rounded-lg w-[382px] h-[278px]">
-      <div className="flex flex-col px-[27px] py-[36px] w-full h-full bg-white rounded-lg border border-solid shadow-sm border-black border-opacity-10">
+      <div className="flex flex-col px-[27px] py-[36px] w-full h-full bg-white rounded-lg border border-solid shadow-lg border-black border-opacity-10">
         <h2 className="self-start font-bold text-zinc-700 ">{projectName}</h2>
         <hr className="shrink-0 my-[31px] h-px border border-solid border-black border-opacity-10" />
         <p className="self-start text-base leading-tight text-neutral-400 overflow-hidden font-normal">

--- a/front/src/app/gatherings/[id]/_components/RecruitmentStatus.tsx
+++ b/front/src/app/gatherings/[id]/_components/RecruitmentStatus.tsx
@@ -1,35 +1,51 @@
-export default function RecruitmentStatus() {
-  interface DeveloperTypeItem {
-    title: string;
-    current: number;
-    total: number;
-  }
+import React from "react";
+import Image from "next/image";
+import UserInfoCard from "./UserInfoCard";
 
-  const developerTypes = [
-    { title: "웹프론트엔드", current: 1, total: 4 },
-    { title: "웹프론트엔드", current: 2, total: 4 },
-    { title: "백엔드", current: 2, total: 4 },
-    { title: "안드개발자", current: 1, total: 3 },
-    { title: "AI개발자", current: 1, total: 4 },
-    { title: "IOS개발자", current: 1, total: 2 },
-  ];
+interface DeveloperTypeItem {
+  title: string;
+  current: number;
+  total: number;
+}
 
-  const DeveloperTypeItem = ({ title, current, total }: DeveloperTypeItem) => (
-    <div className="flex w-[222px] justify-between items-center">
-      <span className="text-2xl text-[#9a9a9a]">{title}</span>
-      <span className="text-2xl text-[#484848]">
-        {current}/{total}
-      </span>
-    </div>
-  );
+const tempUserData = {
+  nickname: "사용자닉네임",
+  avatar: "/api/placeholder/40/40",
+  temperature: 75,
+};
+
+export default function DeveloperTypeItem({
+  title,
+  current,
+  total,
+}: DeveloperTypeItem) {
+  const displayAvatars = current >= 5;
 
   return (
-    <div className="w-[753px] h-[210px] p-10 rounded-lg bg-[#f4f5f6]">
-      <div className="grid grid-cols-2 gap-x-4 gap-y-5">
-        {developerTypes.map((developerType, title) => (
-          <DeveloperTypeItem key={title} {...developerType} />
-        ))}
-      </div>
+    <div className="flex w-[222px] justify-between items-center">
+      <span className="text-2xl text-[#9a9a9a] ">{title}</span>
+      {displayAvatars ? (
+        <div className="flex -space-x-2 overflow-hidden group">
+          {[...Array(4)].map((_, index) => (
+            <div
+              key={index}
+              className="relative w-10 h-10 rounded-full bg-gray-300 hover:z-10 group"
+            >
+              <Image
+                src={tempUserData.avatar}
+                alt="avatar"
+                layout="fill"
+                className="rounded-full"
+              />
+              <div className="absolute top-12 left-0 hidden group-hover:block z-20">
+                <UserInfoCard tempUserData={tempUserData} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <span className="text-2xl text-gray-12">{`${current}/${total}`}</span>
+      )}
     </div>
   );
 }

--- a/front/src/app/gatherings/[id]/_components/UserInfoCard.tsx
+++ b/front/src/app/gatherings/[id]/_components/UserInfoCard.tsx
@@ -1,0 +1,39 @@
+import Image from "next/image";
+
+interface UserInfoCardProps {
+  tempUserData: {
+    nickname: string;
+    avatar?: string;
+    temperature: number;
+  };
+}
+
+export default function UserInfoCard({ tempUserData }: UserInfoCardProps) {
+  const { nickname, avatar, temperature } = tempUserData;
+
+  return (
+    <div className="bg-white shadow-lg rounded-lg p-4 w-64 z-20">
+      <div className="flex items-center space-x-4">
+        <div className="relative w-12 h-12">
+          <Image
+            src={avatar ? avatar : "/api/placeholder/40/40"}
+            alt="User avatar"
+            layout="fill"
+            objectFit="cover"
+            className="rounded-full"
+          />
+        </div>
+        <div>
+          <p className="font-semibold text-lg">{nickname}</p>
+          <div className="w-full bg-gray-200 rounded-full h-2.5 mt-2">
+            <div
+              className="bg-blue-600 h-2.5 rounded-full"
+              style={{ width: `${temperature}%` }}
+            ></div>
+          </div>
+          <p className="text-sm text-gray-600 mt-1">온도: {temperature}°</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/app/gatherings/[id]/page.tsx
+++ b/front/src/app/gatherings/[id]/page.tsx
@@ -1,11 +1,98 @@
 "use client";
 
+import DetailHeader from "./_components/DetailHeader";
+import DetailProjectCard from "./_components/DetailProjectCard";
+import RecruitmentStatus from "./_components/RecruitmentStatus";
 import CommentDisplay from "./_components/CommentDisplay";
 
+/* 
+  TODO:
+    1. 실제 백엔드 데이터가 만들어지면 그 양식에 맡게 리팩토링예정 (양식도 안나오는 부분이있음 ex) 댓글)
+    2. 아바타 호버시 프로필 보여주기 기능 안되고있음
+    3. 전체적으로 디자인이 나오지않아 와이어 프레임을 따라가고있어서 
+        디자인이 나왔을때 전체적으로 css 수정예정( 현재 와이어 프레임의 기능 구현)
+    4. 댓글 기능 store 에 저장되어있는 훅들 리팩토링 예정
+    5. 리액트 쿼리 활용한 백엔드 데이터 받을 준비
+    6. 아이콘 양식 생기면 그에 맡게 매칭시키기.
+*/
+
 export default function Page() {
+  const projectData = {
+    name: "[전라북도] 어플리케이션 개발",
+    description: "프로젝트에 대한 간단한 설명...",
+  };
+
+  const recruitmentData = [
+    { title: "웹프론트엔드", current: 1, total: 4 },
+    { title: "백엔드", current: 2, total: 4 },
+    { title: "AI개발자", current: 1, total: 4 },
+    { title: "웹프론트엔드", current: 2, total: 4 },
+    { title: "안드개발자", current: 1, total: 3 },
+    { title: "IOS개발자", current: 1, total: 2 },
+  ];
+
   return (
-    <div className="bg-white min-h-screen">
-      <CommentDisplay />
+    <div className="flex justify-center bg-white min-h-screen mb-20">
+      <div className="w-full max-w-[1200px] px-4">
+        <div className="flex justify-between items-start mb-8">
+          <div className="flex flex-col w-[753px]">
+            <DetailHeader />
+            <div className="flex">
+              <div className="flex-grow">
+                <section className="mb-8">
+                  <h2 className="text-2xl font-bold mb-4">모집현황</h2>
+                  <div className="bg-gray-100 p-10 rounded-lg">
+                    <div className="grid grid-cols-2 gap-4">
+                      {recruitmentData.map((item, index) => (
+                        <RecruitmentStatus key={index} {...item} />
+                      ))}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="mb-8">
+                  <h2 className="text-2xl font-bold mb-4">
+                    스터디 & 네트워킹 키워드
+                  </h2>
+                  <div className="flex gap-2">
+                    {[...Array(7)].map((_, i) => (
+                      <div
+                        key={i}
+                        className="w-[80px] h-[80px] bg-gray-200 rounded-full"
+                      ></div>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="mb-8">
+                  <h2 className="text-2xl font-bold mb-4">소개</h2>
+                  <p className="text-gray-700">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat.Lorem ipsum dolor sit amet, consectetur adipiscing
+                    elit, sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat.
+                  </p>
+                </section>
+              </div>
+            </div>
+          </div>
+          <DetailProjectCard
+            projectName={projectData.name}
+            description={projectData.description}
+            onParticipate={() => console.log("참여하기 클릭")}
+          />
+        </div>
+        <CommentDisplay />
+      </div>
     </div>
   );
 }

--- a/front/src/app/gatherings/[id]/page.tsx
+++ b/front/src/app/gatherings/[id]/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
 
   return (
     <div className="flex justify-center bg-white min-h-screen mb-20">
-      <div className="w-full max-w-[1200px] px-4">
+      <div className="w-full max-w-[1200px] px-4 ml-[49px]">
         <div className="flex justify-between items-start mb-8">
           <div className="flex flex-col w-[753px]">
             <DetailHeader />

--- a/front/src/app/gatherings/[id]/page.tsx
+++ b/front/src/app/gatherings/[id]/page.tsx
@@ -1,25 +1,11 @@
 "use client";
 
-import DetailHeader from "./_components/DetailHeader";
-import DetailProjectCard from "./_components/DetailProjectCard";
-import RecruitmentStatus from "./_components/RecruitmentStatus";
+import CommentDisplay from "./_components/CommentDisplay";
 
-export default function page() {
+export default function Page() {
   return (
     <div className="bg-white min-h-screen">
-      <DetailHeader />
-      <DetailProjectCard
-        projectName="이름"
-        description="설명"
-        onParticipate={() => {
-          console.log("test");
-        }}
-      />
-      <span className="text-[28px] font-semibold text-[#484848]">모집현황</span>
-      <RecruitmentStatus />
-      <span className="text-[28px] font-semibold text-[#484848]">
-        스터디 & 네트워킹 키워드
-      </span>
+      <CommentDisplay />
     </div>
   );
 }

--- a/front/src/store/gatheringsDetail/useCommentStore.ts
+++ b/front/src/store/gatheringsDetail/useCommentStore.ts
@@ -1,0 +1,89 @@
+import { create } from "zustand";
+import { CommentState, Comment } from "@/types/gatheringsDetail/comment";
+
+// 댓글 추가 , 답글 추가 , 댓글 or 답글 삭제 기능입니다 단 백엔드 연동이 된 후에 리팩토링이 무조건적으로 되어야하는 부분입니다.
+
+const addReplyToComment = (
+  comment: Comment,
+  parentId: number,
+  newReply: Comment,
+): Comment => {
+  if (comment.id === parentId) {
+    return {
+      ...comment,
+      replies: [...(comment.replies || []), newReply],
+    };
+  }
+  if (comment.replies) {
+    return {
+      ...comment,
+      replies: comment.replies.map((reply) =>
+        addReplyToComment(reply, parentId, newReply),
+      ),
+    };
+  }
+  return comment;
+};
+
+const removeCommentById = (comments: Comment[], id: number): Comment[] => {
+  return comments.filter((comment) => {
+    if (comment.id === id) {
+      return false;
+    }
+    if (comment.replies) {
+      comment.replies = removeCommentById(comment.replies, id);
+    }
+    return true;
+  });
+};
+
+export const useCommentStore = create<CommentState>((set) => ({
+  comments: [
+    {
+      id: 1,
+      text: "오 근데 이거 아이템 이상한대요?",
+      user: "징니",
+      createdAt: "10분전",
+      replies: [
+        {
+          id: 2,
+          text: "@징니 ??????네 진짜요?",
+          user: "김댓글",
+          createdAt: "10분전",
+        },
+      ],
+    },
+  ],
+
+  addComment: (text: string) =>
+    set((state) => ({
+      comments: [
+        ...state.comments,
+        {
+          id: Date.now(),
+          text,
+          user: "현재 사용자",
+          createdAt: "방금 전",
+          replies: [],
+        },
+      ],
+    })),
+
+  addReply: (parentId: number, text: string) =>
+    set((state) => ({
+      comments: state.comments.map((comment) =>
+        addReplyToComment(comment, parentId, {
+          id: Date.now(),
+          text,
+          user: "현재 사용자",
+          createdAt: "방금 전",
+          replies: [],
+        }),
+      ),
+    })),
+
+  deleteComment: (id: number) =>
+    set((state) => ({
+      comments: removeCommentById(state.comments, id),
+    })),
+}));

--- a/front/src/types/gatheringsDetail/comment.ts
+++ b/front/src/types/gatheringsDetail/comment.ts
@@ -1,0 +1,16 @@
+//임시로 만든 댓글의 타입입니다. 추후 수정이 필요합니다.
+
+export interface Comment {
+  id: number;
+  text: string;
+  user: string;
+  createdAt: string;
+  replies?: Comment[];
+}
+
+export interface CommentState {
+  comments: Comment[];
+  addComment: (text: string) => void;
+  addReply: (parentId: number, text: string) => void;
+  deleteComment: (id: number) => void;
+}


### PR DESCRIPTION
  TODO:
    1. 실제 백엔드 데이터가 만들어지면 그 양식에 맡게 리팩토링예정 (양식도 안나오는 부분이있음 ex) 댓글)
    2. 아바타 호버시 프로필 보여주기 기능 안되고있음
    3. 전체적으로 디자인이 나오지않아 와이어 프레임을 따라가고있어서 
        디자인이 나왔을때 전체적으로 css 수정예정( 현재 와이어 프레임의 기능 구현)
    4. 댓글 기능 store 에 저장되어있는 훅들 리팩토링 예정
    5. 리액트 쿼리 활용한 백엔드 데이터 받을 준비
    6. 아이콘 양식 생기면 그에 맡게 매칭시키기.

  모임 상세 페이지의 전체 레이아웃을 구현 하였습니다.
  
  
<img width="849" alt="image" src="https://github.com/user-attachments/assets/366de329-d73d-45fa-aafa-cbb3463b9e94">

 와이어 프레임밖에 나오지않는 상태라 조금 css가 지저분합니다 추후 디자인이 나왔을때 빠르게 리팩토링하겠습니다.
 